### PR TITLE
Add SDR radio bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,18 @@ An offline-first emergency preparedness assistant powered by a local language mo
 * **SDR radio bridge** to send/receive text bulletins in austere environments.
 * **Encrypted local storage** for personal data and cached responses.
 
+### SDR Radio Bridge
+
+The `prepper` CLI includes a simple radio bridge that communicates with a
+serial-connected transceiver or TNC. Use it to broadcast or receive short text
+bulletins when the internet is unavailable:
+
+```bash
+# Send a message over /dev/ttyUSB0 at 9600 baud
+prepper radio send --message "Storm approaching, shelter at 6pm" 
+
+# Listen for incoming messages
+prepper radio listen
+```
+
 See `plan.md` for the detailed roadmap.

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "nodemon": "^3.1.0",
     "prisma": "^5.15.0",
     "supertest": "^6.3.4"
+  },
+  "jest": {
+    "testPathIgnorePatterns": ["/tests/e2e/"]
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ uvicorn[standard]==0.29.0
 vllm==0.4.0
 psutil==5.9.8
 requests==2.32.3
+pyserial==3.5

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -5,6 +5,7 @@ const { askQuestion } = require('./qa');
 const { getSupplyInfo } = require('./supplies');
 const { handleFoodItemCommand } = require('./foodItems');
 const { handleMeshCommand, printHelp } = require('./mesh');
+const { handleRadioCommand } = require('./radio');
 
 const program = new Command();
 
@@ -74,6 +75,19 @@ program
       if (command === 'start') {
         console.log('\nFor more information, use: prepper mesh --help');
       }
+    }
+  });
+
+program
+  .command('radio')
+  .description('Send or receive bulletins via SDR')
+  .argument('<command>', 'Command to execute: send or listen')
+  .option('-m, --message <text>', 'Message to send when using send command')
+  .action(async (command, options) => {
+    try {
+      await handleRadioCommand(options, command);
+    } catch (error) {
+      console.error('Error:', error.message);
     }
   });
 

--- a/src/cli/radio.js
+++ b/src/cli/radio.js
@@ -1,0 +1,30 @@
+const { spawn } = require('child_process');
+const path = require('path');
+
+/**
+ * Wrapper to interact with the SDR bridge Python script.
+ */
+function runBridge(args = []) {
+  return new Promise((resolve) => {
+    const python = process.env.PYTHON || 'python3';
+    const script = path.join(__dirname, '..', 'sdr', 'bridge.py');
+    const proc = spawn(python, [script, ...args], { stdio: 'inherit' });
+    proc.on('exit', (code) => resolve(code ?? 0));
+  });
+}
+
+async function handleRadioCommand(options, command) {
+  if (command === 'send') {
+    if (!options.message) {
+      console.error('Please provide a message with --message');
+      return;
+    }
+    await runBridge(['send', options.message]);
+  } else if (command === 'listen') {
+    await runBridge(['listen']);
+  } else {
+    console.log('Unknown command. Use send or listen.');
+  }
+}
+
+module.exports = { handleRadioCommand };

--- a/src/sdr/bridge.py
+++ b/src/sdr/bridge.py
@@ -1,0 +1,52 @@
+import argparse
+import sys
+import time
+from typing import Optional
+
+import serial
+
+
+def open_port(port: str, baud: int) -> serial.Serial:
+    """Open serial port."""
+    return serial.Serial(port=port, baudrate=baud, timeout=1)
+
+
+def send_bulletin(text: str, port: str = "/dev/ttyUSB0", baud: int = 9600):
+    """Send a text bulletin via serial radio/tnc."""
+    with open_port(port, baud) as ser:
+        ser.write(text.encode("utf-8") + b"\n")
+        ser.flush()
+
+
+def listen(port: str = "/dev/ttyUSB0", baud: int = 9600):
+    """Continuously read bulletins from the serial port."""
+    with open_port(port, baud) as ser:
+        try:
+            while True:
+                line = ser.readline()
+                if line:
+                    ts = time.strftime("%Y-%m-%d %H:%M:%S")
+                    print(f"[{ts}] {line.decode('utf-8', 'ignore').strip()}")
+        except KeyboardInterrupt:
+            return
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="SDR text bulletin bridge")
+    p.add_argument("command", choices=["send", "listen"], help="Action to perform")
+    p.add_argument("message", nargs="?", help="Message to send")
+    p.add_argument("--port", default="/dev/ttyUSB0")
+    p.add_argument("--baud", type=int, default=9600)
+    args = p.parse_args(argv)
+
+    if args.command == "send":
+        if not args.message:
+            print("Message required for send", file=sys.stderr)
+            return 1
+        send_bulletin(args.message, args.port, args.baud)
+    else:
+        listen(args.port, args.baud)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- integrate `pyserial` and add SDR radio bridge script
- expose `radio` command in the CLI
- document how to use the radio bridge in `README`
- prevent Playwright e2e tests from running with Jest

## Testing
- `node node_modules/jest/bin/jest.js`

------
https://chatgpt.com/codex/tasks/task_e_686ffe8c2ad88331be40b541f53d894a